### PR TITLE
fix: Exclusively use UTC Date internally

### DIFF
--- a/lib/arithmetic.ts
+++ b/lib/arithmetic.ts
@@ -1,5 +1,6 @@
 import ProperDate from "./model";
 import type { ArithmeticOptions } from "./types";
+import { buildUtcDate } from "./utils";
 
 const DEFAULT_OPTIONS: ArithmeticOptions = { period: "days" };
 
@@ -14,13 +15,12 @@ export const add = (base: ProperDate, n: number, options: ArithmeticOptions = DE
 
   if (period === "day" || period === "days") {
     const baseDate = base.toDate();
-    const newDate = new Date(baseDate.getTime());
-    newDate.setDate(baseDate.getDate() + n);
+    const newDate = buildUtcDate(baseDate.getFullYear(), baseDate.getMonth() + 1, baseDate.getDate() + n);
     return new ProperDate(newDate);
   }
   if (period === "month" || period === "months") {
     const baseDate = base.toDate();
-    const targetDate = new Date(Date.UTC(baseDate.getFullYear(), baseDate.getMonth() + n, baseDate.getDate()));
+    const targetDate = buildUtcDate(baseDate.getFullYear(), baseDate.getMonth() + 1 + n, baseDate.getDate());
 
     // Handle cases where the target date overflows to the next month
     // // Calculate expected month: original month + n, then take modulo 12

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -4,10 +4,10 @@ import { parseInput } from "./utils";
 
 export default class ProperDate {
   year: number;
-  month: number;
+  month: number; // TODO: follows JS data convention of 0-11 for months; change this to 1-12
   day: number;
 
-  constructor(date: Date | ProperDate | string = new Date()) {
+  constructor(date: Date | ProperDate | string | number[] = new Date()) {
     const { year, month, day } = parseInput(date);
     this.year = year;
     this.month = month;

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -2,12 +2,20 @@ import { add, difference, subtract } from "./arithmetic";
 import type { ArithmeticOptions, Period } from "./types";
 import { buildUtcDate, parseInput } from "./utils";
 
+const getDefaultDate = (): string => {
+  return new Date().toISOString().split("T")[0];
+}
+
 export default class ProperDate {
   year: number;
   month: number; // TODO: follows JS data convention of 0-11 for months; change this to 1-12
   day: number;
 
-  constructor(date: Date | ProperDate | string | number[] = new Date()) {
+  constructor(date: Date | ProperDate | string | number[] | undefined = undefined) {
+    if (date === undefined) {
+      date = getDefaultDate();
+    }
+
     const { year, month, day } = parseInput(date);
     this.year = year;
     this.month = month;

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -4,7 +4,7 @@ import { buildUtcDate, parseInput } from "./utils";
 
 const getDefaultDate = (): string => {
   return new Date().toISOString().split("T")[0];
-}
+};
 
 export default class ProperDate {
   year: number;

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -1,6 +1,6 @@
 import { add, difference, subtract } from "./arithmetic";
 import type { ArithmeticOptions, Period } from "./types";
-import { parseInput } from "./utils";
+import { buildUtcDate, parseInput } from "./utils";
 
 export default class ProperDate {
   year: number;
@@ -26,12 +26,16 @@ export default class ProperDate {
     return this.subtract(1, "year").endOfYear;
   }
 
+  get actualMonth(): number {
+    return this.month + 1;
+  }
+
   get endOfMonth(): ProperDate {
-    return new ProperDate(new Date(Date.UTC(this.year, this.month + 1, 0)));
+    return new ProperDate(buildUtcDate(this.year, this.actualMonth + 1, 0));
   }
 
   get endOfYear(): ProperDate {
-    return new ProperDate([this.year, 12, 31]);
+    return new ProperDate(buildUtcDate(this.year, 12, 31));
   }
 
   equals(other: ProperDate): boolean {
@@ -47,7 +51,7 @@ export default class ProperDate {
   }
 
   toDate(): Date {
-    return new Date(this.toString());
+    return this.jsDate;
   }
 
   /**
@@ -98,6 +102,6 @@ export default class ProperDate {
   }
 
   private get jsDate(): Date {
-    return new Date(Date.UTC(this.year, this.month, this.day));
+    return buildUtcDate(this.year, this.actualMonth, this.day);
   }
 }

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -31,7 +31,7 @@ export default class ProperDate {
   }
 
   get endOfYear(): ProperDate {
-    return new ProperDate(new Date(Date.UTC(this.year, 11, 31)));
+    return new ProperDate([this.year, 12, 31]);
   }
 
   equals(other: ProperDate): boolean {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,13 +1,13 @@
 import ProperDate from "./model";
 
 export const buildUtcDate = (year: number, month: number, day: number): Date => {
-  return new Date(Date.UTC(year, month - 1, day))
-}
+  return new Date(Date.UTC(year, month - 1, day));
+};
 
 export const buildUtcDateFromString = (value: string): Date => {
   const [year, month, day] = value.split("-").map(Number);
   return buildUtcDate(year, month, day);
-}
+};
 
 export const parseInput = (date: ProperDate | Date | string | number[]) => {
   let year: number;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,14 @@
 import ProperDate from "./model";
 
+export const buildUtcDate = (year: number, month: number, day: number): Date => {
+  return new Date(Date.UTC(year, month - 1, day))
+}
+
+export const buildUtcDateFromString = (value: string): Date => {
+  const [year, month, day] = value.split("-").map(Number);
+  return buildUtcDate(year, month, day);
+}
+
 export const parseInput = (date: ProperDate | Date | string | number[]) => {
   let year: number;
   let month: number;
@@ -14,12 +23,12 @@ export const parseInput = (date: ProperDate | Date | string | number[]) => {
     month = date.getMonth();
     day = date.getDate();
   } else if (Array.isArray(date) && date.length === 3) {
-    const parsedDate = new Date(Date.UTC(date[0], date[1] - 1, date[2]));
+    const parsedDate = buildUtcDate(date[0], date[1], date[2]);
     year = parsedDate.getFullYear();
     month = parsedDate.getMonth();
     day = parsedDate.getDate();
   } else if (typeof date === "string" && isValidDateFormat(date)) {
-    const parsedDate = new Date(date);
+    const parsedDate = buildUtcDateFromString(date);
     year = parsedDate.getFullYear();
     month = parsedDate.getMonth();
     day = parsedDate.getDate();
@@ -38,7 +47,7 @@ function isValidDateFormat(dateString: string): boolean {
   }
 
   // Further validate the date is real
-  const date = new Date(dateString);
+  const date = buildUtcDateFromString(dateString);
   const [year, month, day] = dateString.split("-").map(Number);
 
   return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,7 +14,7 @@ export const parseInput = (date: ProperDate | Date | string | number[]) => {
     month = date.getMonth();
     day = date.getDate();
   } else if (Array.isArray(date) && date.length === 3) {
-    const parsedDate = new Date(date[0], date[1] - 1, date[2]);
+    const parsedDate = new Date(Date.UTC(date[0], date[1] - 1, date[2]));
     year = parsedDate.getFullYear();
     month = parsedDate.getMonth();
     day = parsedDate.getDate();

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,6 @@
 import ProperDate from "./model";
 
-export const parseInput = (date: ProperDate | Date | string) => {
+export const parseInput = (date: ProperDate | Date | string | number[]) => {
   let year: number;
   let month: number;
   let day: number;
@@ -13,6 +13,11 @@ export const parseInput = (date: ProperDate | Date | string) => {
     year = date.getFullYear();
     month = date.getMonth();
     day = date.getDate();
+  } else if (Array.isArray(date) && date.length === 3) {
+    const parsedDate = new Date(date[0], date[1] - 1, date[2]);
+    year = parsedDate.getFullYear();
+    month = parsedDate.getMonth();
+    day = parsedDate.getDate();
   } else if (typeof date === "string" && isValidDateFormat(date)) {
     const parsedDate = new Date(date);
     year = parsedDate.getFullYear();

--- a/tests/arithmetic.test.ts
+++ b/tests/arithmetic.test.ts
@@ -1,90 +1,91 @@
 import ProperDate from "../lib";
 import { add, difference, subtract } from "../lib/arithmetic";
+import { expectEqualDates } from "./support/matchers";
 
 describe("arithmetic", () => {
   // TODO: Review these results, particularly months-related logic: https://github.com/still-forest/proper-date.js/issues/22
   describe("add", () => {
     test("by default, returns ProperDate with days added", () => {
       const base = new ProperDate("2023-12-25");
-      expect(add(base, 1)).toStrictEqual(new ProperDate("2023-12-26"));
-      expect(add(base, 2)).toStrictEqual(new ProperDate("2023-12-27"));
-      expect(add(base, 10)).toStrictEqual(new ProperDate("2024-01-04"));
-      expect(add(base, 365)).toStrictEqual(new ProperDate("2024-12-24"));
+      expectEqualDates(add(base, 1), new ProperDate("2023-12-26"));
+      expectEqualDates(add(base, 2), new ProperDate("2023-12-27"));
+      expectEqualDates(add(base, 10), new ProperDate("2024-01-04"));
+      expectEqualDates(add(base, 365), new ProperDate("2024-12-24"));
     });
 
     test("with days, returns ProperDate with days added", () => {
       const base = new ProperDate("2023-12-25");
-      expect(add(base, 1, { period: "day" })).toStrictEqual(new ProperDate("2023-12-26"));
-      expect(add(base, 2, { period: "days" })).toStrictEqual(new ProperDate("2023-12-27"));
-      expect(add(base, 10, { period: "days" })).toStrictEqual(new ProperDate("2024-01-04"));
-      expect(add(base, 365, { period: "days" })).toStrictEqual(new ProperDate("2024-12-24"));
+      expectEqualDates(add(base, 1, { period: "day" }), new ProperDate("2023-12-26"));
+      expectEqualDates(add(base, 2, { period: "days" }), new ProperDate("2023-12-27"));
+      expectEqualDates(add(base, 10, { period: "days" }), new ProperDate("2024-01-04"));
+      expectEqualDates(add(base, 365, { period: "days" }), new ProperDate("2024-12-24"));
     });
 
     test("with months, returns ProperDate with months added", () => {
       const base = new ProperDate("2023-12-25");
-      expect(add(base, 1, { period: "month" })).toStrictEqual(new ProperDate("2024-01-25"));
-      expect(add(base, 2, { period: "months" })).toStrictEqual(new ProperDate("2024-02-25"));
-      expect(add(base, 10, { period: "months" })).toStrictEqual(new ProperDate("2024-10-25"));
-      expect(add(base, 120, { period: "months" })).toStrictEqual(new ProperDate("2033-12-25"));
+      expectEqualDates(add(base, 1, { period: "month" }), new ProperDate("2024-01-25"));
+      expectEqualDates(add(base, 2, { period: "months" }), new ProperDate("2024-02-25"));
+      expectEqualDates(add(base, 10, { period: "months" }), new ProperDate("2024-10-25"));
+      expectEqualDates(add(base, 120, { period: "months" }), new ProperDate("2033-12-25"));
     });
 
     test("with months, overlaps months properly", () => {
       const base = new ProperDate("2023-01-31");
-      expect(add(base, 1, { period: "month" })).toStrictEqual(new ProperDate("2023-02-28"));
-      expect(add(base, 13, { period: "months" })).toStrictEqual(new ProperDate("2024-02-29"));
+      expectEqualDates(add(base, 1, { period: "month" }), new ProperDate("2023-02-28"));
+      expectEqualDates(add(base, 13, { period: "months" }), new ProperDate("2024-02-29"));
 
       const thirtyDayMonth = new ProperDate("2023-04-30");
-      expect(add(thirtyDayMonth, 1, { period: "month" })).toStrictEqual(new ProperDate("2023-05-30"));
+      expectEqualDates(add(thirtyDayMonth, 1, { period: "month" }), new ProperDate("2023-05-30"));
     });
 
     test("with years, returns ProperDate with years added", () => {
       const base = new ProperDate("2023-12-25");
-      expect(add(base, 1, { period: "year" })).toStrictEqual(new ProperDate("2024-12-25"));
-      expect(add(base, 2, { period: "years" })).toStrictEqual(new ProperDate("2025-12-25"));
-      expect(add(base, 10, { period: "years" })).toStrictEqual(new ProperDate("2033-12-25"));
-      expect(add(base, 120, { period: "years" })).toStrictEqual(new ProperDate("2143-12-25"));
+      expectEqualDates(add(base, 1, { period: "year" }), new ProperDate("2024-12-25"));
+      expectEqualDates(add(base, 2, { period: "years" }), new ProperDate("2025-12-25"));
+      expectEqualDates(add(base, 10, { period: "years" }), new ProperDate("2033-12-25"));
+      expectEqualDates(add(base, 120, { period: "years" }), new ProperDate("2143-12-25"));
     });
 
     // TODO: Review this leap year handling: https://github.com/still-forest/proper-date.js/issues/23
     test("leap day as base handling", () => {
       const leapDay = new ProperDate("2020-02-29");
 
-      expect(add(leapDay, 1, { period: "day" })).toStrictEqual(new ProperDate("2020-03-01"));
-      expect(add(leapDay, 365, { period: "days" })).toStrictEqual(new ProperDate("2021-02-28"));
-      expect(add(leapDay, 1461, { period: "days" })).toStrictEqual(new ProperDate("2024-02-29"));
+      expectEqualDates(add(leapDay, 1, { period: "day" }), new ProperDate("2020-03-01"));
+      expectEqualDates(add(leapDay, 365, { period: "days" }), new ProperDate("2021-02-28"));
+      expectEqualDates(add(leapDay, 1461, { period: "days" }), new ProperDate("2024-02-29"));
 
-      expect(add(leapDay, 1, { period: "month" })).toStrictEqual(new ProperDate("2020-03-29"));
-      expect(add(leapDay, 12, { period: "months" })).toStrictEqual(new ProperDate("2021-02-28"));
-      expect(add(leapDay, 48, { period: "months" })).toStrictEqual(new ProperDate("2024-02-29"));
-      expect(add(leapDay, 60, { period: "months" })).toStrictEqual(new ProperDate("2025-02-28"));
+      expectEqualDates(add(leapDay, 1, { period: "month" }), new ProperDate("2020-03-29"));
+      expectEqualDates(add(leapDay, 12, { period: "months" }), new ProperDate("2021-02-28"));
+      expectEqualDates(add(leapDay, 48, { period: "months" }), new ProperDate("2024-02-29"));
+      expectEqualDates(add(leapDay, 60, { period: "months" }), new ProperDate("2025-02-28"));
 
-      expect(add(leapDay, 1, { period: "year" })).toStrictEqual(new ProperDate("2021-03-01"));
-      expect(add(leapDay, 4, { period: "years" })).toStrictEqual(new ProperDate("2024-02-29"));
-      expect(add(leapDay, 5, { period: "years" })).toStrictEqual(new ProperDate("2025-03-01"));
+      expectEqualDates(add(leapDay, 1, { period: "year" }), new ProperDate("2021-03-01"));
+      expectEqualDates(add(leapDay, 4, { period: "years" }), new ProperDate("2024-02-29"));
+      expectEqualDates(add(leapDay, 5, { period: "years" }), new ProperDate("2025-03-01"));
     });
 
     test("leap year as result handling", () => {
       const dayBeforeLeapDay = new ProperDate("2020-02-28");
       const monthBeforeLeapDay = new ProperDate("2020-01-30");
 
-      expect(add(dayBeforeLeapDay, 1, { period: "day" })).toStrictEqual(new ProperDate("2020-02-29"));
+      expectEqualDates(add(dayBeforeLeapDay, 1, { period: "day" }), new ProperDate("2020-02-29"));
 
-      expect(add(monthBeforeLeapDay, 1, { period: "month" })).toStrictEqual(new ProperDate("2020-02-29"));
-      expect(add(monthBeforeLeapDay, 13, { period: "months" })).toStrictEqual(new ProperDate("2021-02-28"));
-      expect(add(monthBeforeLeapDay, 49, { period: "months" })).toStrictEqual(new ProperDate("2024-02-29"));
-      expect(add(monthBeforeLeapDay, 61, { period: "months" })).toStrictEqual(new ProperDate("2025-02-28"));
+      expectEqualDates(add(monthBeforeLeapDay, 1, { period: "month" }), new ProperDate("2020-02-29"));
+      expectEqualDates(add(monthBeforeLeapDay, 13, { period: "months" }), new ProperDate("2021-02-28"));
+      expectEqualDates(add(monthBeforeLeapDay, 49, { period: "months" }), new ProperDate("2024-02-29"));
+      expectEqualDates(add(monthBeforeLeapDay, 61, { period: "months" }), new ProperDate("2025-02-28"));
     });
 
     test("with zero and negative values", () => {
       const base = new ProperDate("2023-12-25");
 
-      expect(add(base, 0, { period: "days" })).toStrictEqual(base);
-      expect(add(base, 0, { period: "months" })).toStrictEqual(base);
-      expect(add(base, 0, { period: "years" })).toStrictEqual(base);
+      expectEqualDates(add(base, 0, { period: "days" }), base);
+      expectEqualDates(add(base, 0, { period: "months" }), base);
+      expectEqualDates(add(base, 0, { period: "years" }), base);
 
-      expect(add(base, -1, { period: "days" })).toStrictEqual(new ProperDate("2023-12-24"));
-      expect(add(base, -1, { period: "months" })).toStrictEqual(new ProperDate("2023-11-25"));
-      expect(add(base, -1, { period: "year" })).toStrictEqual(new ProperDate("2022-12-25"));
+      expectEqualDates(add(base, -1, { period: "days" }), new ProperDate("2023-12-24"));
+      expectEqualDates(add(base, -1, { period: "months" }), new ProperDate("2023-11-25"));
+      expectEqualDates(add(base, -1, { period: "year" }), new ProperDate("2022-12-25"));
     });
 
     test("throws error for unsupported period", () => {
@@ -100,85 +101,85 @@ describe("arithmetic", () => {
   describe("subtract", () => {
     test("by default, returns ProperDate with days subtracted", () => {
       const base = new ProperDate("2023-12-25");
-      expect(subtract(base, 1)).toStrictEqual(new ProperDate("2023-12-24"));
-      expect(subtract(base, 2)).toStrictEqual(new ProperDate("2023-12-23"));
-      expect(subtract(base, 10)).toStrictEqual(new ProperDate("2023-12-15"));
-      expect(subtract(base, 365)).toStrictEqual(new ProperDate("2022-12-25"));
+      expectEqualDates(subtract(base, 1), new ProperDate("2023-12-24"));
+      expectEqualDates(subtract(base, 2), new ProperDate("2023-12-23"));
+      expectEqualDates(subtract(base, 10), new ProperDate("2023-12-15"));
+      expectEqualDates(subtract(base, 365), new ProperDate("2022-12-25"));
     });
 
     test("with days, returns ProperDate with days subtracted", () => {
       const base = new ProperDate("2023-12-25");
-      expect(subtract(base, 1, { period: "day" })).toStrictEqual(new ProperDate("2023-12-24"));
-      expect(subtract(base, 2, { period: "days" })).toStrictEqual(new ProperDate("2023-12-23"));
-      expect(subtract(base, 10, { period: "days" })).toStrictEqual(new ProperDate("2023-12-15"));
-      expect(subtract(base, 365, { period: "days" })).toStrictEqual(new ProperDate("2022-12-25"));
+      expectEqualDates(subtract(base, 1, { period: "day" }), new ProperDate("2023-12-24"));
+      expectEqualDates(subtract(base, 2, { period: "days" }), new ProperDate("2023-12-23"));
+      expectEqualDates(subtract(base, 10, { period: "days" }), new ProperDate("2023-12-15"));
+      expectEqualDates(subtract(base, 365, { period: "days" }), new ProperDate("2022-12-25"));
     });
 
     test("with months, returns ProperDate with months subtracted", () => {
       const base = new ProperDate("2023-12-25");
-      expect(subtract(base, 1, { period: "month" })).toStrictEqual(new ProperDate("2023-11-25"));
-      expect(subtract(base, 2, { period: "months" })).toStrictEqual(new ProperDate("2023-10-25"));
-      expect(subtract(base, 10, { period: "months" })).toStrictEqual(new ProperDate("2023-02-25"));
-      expect(subtract(base, 120, { period: "months" })).toStrictEqual(new ProperDate("2013-12-25"));
+      expectEqualDates(subtract(base, 1, { period: "month" }), new ProperDate("2023-11-25"));
+      expectEqualDates(subtract(base, 2, { period: "months" }), new ProperDate("2023-10-25"));
+      expectEqualDates(subtract(base, 10, { period: "months" }), new ProperDate("2023-02-25"));
+      expectEqualDates(subtract(base, 120, { period: "months" }), new ProperDate("2013-12-25"));
     });
 
     test("with months, overlaps months properly", () => {
       const base = new ProperDate("2023-03-31");
-      expect(subtract(base, 1, { period: "month" })).toStrictEqual(new ProperDate("2023-02-28"));
-      expect(subtract(base, 13, { period: "months" })).toStrictEqual(new ProperDate("2022-02-28"));
+      expectEqualDates(subtract(base, 1, { period: "month" }), new ProperDate("2023-02-28"));
+      expectEqualDates(subtract(base, 13, { period: "months" }), new ProperDate("2022-02-28"));
 
       const thirtyDayMonth = new ProperDate("2023-04-30");
-      expect(subtract(thirtyDayMonth, 1, { period: "month" })).toStrictEqual(new ProperDate("2023-03-30"));
+      expectEqualDates(subtract(thirtyDayMonth, 1, { period: "month" }), new ProperDate("2023-03-30"));
     });
 
     test("with years, returns ProperDate with years subtracted", () => {
       const base = new ProperDate("2023-12-25");
-      expect(subtract(base, 1, { period: "year" })).toStrictEqual(new ProperDate("2022-12-25"));
-      expect(subtract(base, 2, { period: "years" })).toStrictEqual(new ProperDate("2021-12-25"));
-      expect(subtract(base, 10, { period: "years" })).toStrictEqual(new ProperDate("2013-12-25"));
-      expect(subtract(base, 120, { period: "years" })).toStrictEqual(new ProperDate("1903-12-25"));
+      expectEqualDates(subtract(base, 1, { period: "year" }), new ProperDate("2022-12-25"));
+      expectEqualDates(subtract(base, 2, { period: "years" }), new ProperDate("2021-12-25"));
+      expectEqualDates(subtract(base, 10, { period: "years" }), new ProperDate("2013-12-25"));
+      expectEqualDates(subtract(base, 120, { period: "years" }), new ProperDate("1903-12-25"));
     });
 
     // TODO: Review this leap year handling: https://github.com/still-forest/proper-date.js/issues/23
     test("leap day as base handling", () => {
       const leapDay = new ProperDate("2020-02-29");
 
-      expect(subtract(leapDay, 1, { period: "day" })).toStrictEqual(new ProperDate("2020-02-28"));
-      expect(subtract(leapDay, 365, { period: "days" })).toStrictEqual(new ProperDate("2019-03-01"));
-      expect(subtract(leapDay, 1461, { period: "days" })).toStrictEqual(new ProperDate("2016-02-29"));
+      expectEqualDates(subtract(leapDay, 1, { period: "day" }), new ProperDate("2020-02-28"));
+      expectEqualDates(subtract(leapDay, 365, { period: "days" }), new ProperDate("2019-03-01"));
+      expectEqualDates(subtract(leapDay, 1461, { period: "days" }), new ProperDate("2016-02-29"));
 
-      expect(subtract(leapDay, 1, { period: "month" })).toStrictEqual(new ProperDate("2020-01-29"));
-      expect(subtract(leapDay, 12, { period: "months" })).toStrictEqual(new ProperDate("2019-02-28"));
-      expect(subtract(leapDay, 48, { period: "months" })).toStrictEqual(new ProperDate("2016-02-29"));
-      expect(subtract(leapDay, 60, { period: "months" })).toStrictEqual(new ProperDate("2015-02-28"));
+      expectEqualDates(subtract(leapDay, 1, { period: "month" }), new ProperDate("2020-01-29"));
+      expectEqualDates(subtract(leapDay, 12, { period: "months" }), new ProperDate("2019-02-28"));
+      expectEqualDates(subtract(leapDay, 48, { period: "months" }), new ProperDate("2016-02-29"));
+      expectEqualDates(subtract(leapDay, 60, { period: "months" }), new ProperDate("2015-02-28"));
 
-      expect(subtract(leapDay, 1, { period: "year" })).toStrictEqual(new ProperDate("2019-03-01"));
-      expect(subtract(leapDay, 4, { period: "years" })).toStrictEqual(new ProperDate("2016-02-29"));
-      expect(subtract(leapDay, 5, { period: "years" })).toStrictEqual(new ProperDate("2015-03-01"));
+      expectEqualDates(subtract(leapDay, 1, { period: "year" }), new ProperDate("2019-03-01"));
+      expectEqualDates(subtract(leapDay, 4, { period: "years" }), new ProperDate("2016-02-29"));
+      expectEqualDates(subtract(leapDay, 5, { period: "years" }), new ProperDate("2015-03-01"));
     });
 
     test("leap year as result handling", () => {
       const dayAfterLeapDay = new ProperDate("2020-03-01");
       const monthAfterLeapDay = new ProperDate("2020-03-29");
 
-      expect(subtract(dayAfterLeapDay, 1, { period: "day" })).toStrictEqual(new ProperDate("2020-02-29"));
+      expectEqualDates(subtract(dayAfterLeapDay, 1, { period: "day" }), new ProperDate("2020-02-29"));
 
-      expect(subtract(monthAfterLeapDay, 1, { period: "month" })).toStrictEqual(new ProperDate("2020-02-29"));
-      expect(subtract(monthAfterLeapDay, 13, { period: "months" })).toStrictEqual(new ProperDate("2019-02-28"));
-      expect(subtract(monthAfterLeapDay, 49, { period: "months" })).toStrictEqual(new ProperDate("2016-02-29"));
-      expect(subtract(monthAfterLeapDay, 61, { period: "months" })).toStrictEqual(new ProperDate("2015-02-28"));
+      expectEqualDates(subtract(monthAfterLeapDay, 1, { period: "month" }), new ProperDate("2020-02-29"));
+      expectEqualDates(subtract(monthAfterLeapDay, 13, { period: "months" }), new ProperDate("2019-02-28"));
+      expectEqualDates(subtract(monthAfterLeapDay, 49, { period: "months" }), new ProperDate("2016-02-29"));
+      expectEqualDates(subtract(monthAfterLeapDay, 61, { period: "months" }), new ProperDate("2015-02-28"));
     });
 
     test("with zero and negative values", () => {
       const base = new ProperDate("2023-12-25");
 
-      expect(subtract(base, 0, { period: "days" })).toStrictEqual(base);
-      expect(subtract(base, 0, { period: "months" })).toStrictEqual(base);
-      expect(subtract(base, 0, { period: "years" })).toStrictEqual(base);
+      expectEqualDates(subtract(base, 0, { period: "days" }), base);
+      expectEqualDates(subtract(base, 0, { period: "months" }), base);
+      expectEqualDates(subtract(base, 0, { period: "years" }), base);
 
-      expect(subtract(base, -1, { period: "days" })).toStrictEqual(new ProperDate("2023-12-26"));
-      expect(subtract(base, -1, { period: "months" })).toStrictEqual(new ProperDate("2024-01-25"));
-      expect(subtract(base, -1, { period: "year" })).toStrictEqual(new ProperDate("2024-12-25"));
+      expectEqualDates(subtract(base, -1, { period: "days" }), new ProperDate("2023-12-26"));
+      expectEqualDates(subtract(base, -1, { period: "months" }), new ProperDate("2024-01-25"));
+      expectEqualDates(subtract(base, -1, { period: "year" }), new ProperDate("2024-12-25"));
     });
 
     test("throws error for unsupported period", () => {

--- a/tests/factory.test.ts
+++ b/tests/factory.test.ts
@@ -1,5 +1,6 @@
 import { getToday, getYesterday } from "../lib/factory";
 import ProperDate from "../lib/model";
+import { expectEqualDates } from "./support/matchers";
 
 describe("factory", () => {
   beforeEach(() => {
@@ -14,14 +15,14 @@ describe("factory", () => {
   describe("today", () => {
     test("returns a ProperDate instance for today's date", () => {
       const subject = getToday();
-      expect(subject.equals(new ProperDate("2025-01-02"))).toStrictEqual(true);
+      expectEqualDates(subject, new ProperDate("2025-01-02"));
     });
   });
 
   describe("yesterday", () => {
     test("returns a ProperDate instance for yesterday's date", () => {
       const subject = getYesterday();
-      expect(subject.equals(new ProperDate("2025-01-01"))).toStrictEqual(true);
+      expectEqualDates(subject, new ProperDate("2025-01-01"));
     });
   });
 });

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -1,4 +1,5 @@
 import ProperDate from "../lib";
+import { expectEqualDates } from "./support/matchers";
 
 describe("model", () => {
   describe("constructor", () => {
@@ -65,16 +66,16 @@ describe("model", () => {
     test("returns true if the dates are equal", () => {
       const subject = new ProperDate("2023-12-25");
 
-      expect(subject.equals(new ProperDate("2023-12-25"))).toStrictEqual(true);
+      expectEqualDates(subject, new ProperDate("2023-12-25"))
       expect(subject.equals(new ProperDate(new Date("2023-12-25")))).toStrictEqual(true);
       expect(subject.equals(new ProperDate(new Date(Date.UTC(2023, 11, 25))))).toStrictEqual(true);
     });
 
     test("returns false when the dates are not equal", () => {
       const subject = new ProperDate("2023-12-25");
-      expect(subject.equals(new ProperDate("2023-12-24"))).toStrictEqual(false);
-      expect(subject.equals(new ProperDate(new Date("2023-12-24")))).toStrictEqual(false);
-      expect(subject.equals(new ProperDate(new Date(Date.UTC(2023, 11, 24))))).toStrictEqual(false);
+      expect(subject.equals(new ProperDate("2023-12-24"))).toBe(false);
+      expect(subject.equals(new ProperDate(new Date("2023-12-24")))).toBe(false);
+      expect(subject.equals(new ProperDate(new Date(Date.UTC(2023, 11, 24))))).toBe(false);
     });
   });
 
@@ -95,32 +96,32 @@ describe("model", () => {
   describe("#add", () => {
     test("adds days, months, or years to the date, returning a new ProperDate", () => {
       const subject = new ProperDate("2023-12-25");
-      expect(subject.add(1, "day")).toStrictEqual(new ProperDate("2023-12-26"));
-      expect(subject.add(2, "months")).toStrictEqual(new ProperDate("2024-02-25"));
-      expect(subject.add(10, "years")).toStrictEqual(new ProperDate("2033-12-25"));
+      expectEqualDates(subject.add(1, "day"), new ProperDate("2023-12-26"));
+      expectEqualDates(subject.add(2, "months"), new ProperDate("2024-02-25"));
+      expectEqualDates(subject.add(10, "years"), new ProperDate("2033-12-25"));
     });
 
     test("accepts an option object", () => {
       const subject = new ProperDate("2023-12-25");
-      expect(subject.add(1, { period: "day" })).toStrictEqual(new ProperDate("2023-12-26"));
-      expect(subject.add(2, { period: "months" })).toStrictEqual(new ProperDate("2024-02-25"));
-      expect(subject.add(10, { period: "years" })).toStrictEqual(new ProperDate("2033-12-25"));
+      expectEqualDates(subject.add(1, { period: "day" }), new ProperDate("2023-12-26"));
+      expectEqualDates(subject.add(2, { period: "months" }), new ProperDate("2024-02-25"));
+      expectEqualDates(subject.add(10, { period: "years" }), new ProperDate("2033-12-25"));
     });
   });
 
   describe("#subtract", () => {
     test("subtracts days, months, or years to the date, returning a new ProperDate", () => {
       const subject = new ProperDate("2023-12-25");
-      expect(subject.subtract(1, "day")).toStrictEqual(new ProperDate("2023-12-24"));
-      expect(subject.subtract(2, "months")).toStrictEqual(new ProperDate("2023-10-25"));
-      expect(subject.subtract(10, "years")).toStrictEqual(new ProperDate("2013-12-25"));
+      expectEqualDates(subject.subtract(1, "day"), new ProperDate("2023-12-24"));
+      expectEqualDates(subject.subtract(2, "months"), new ProperDate("2023-10-25"));
+      expectEqualDates(subject.subtract(10, "years"), new ProperDate("2013-12-25"));
     });
 
     test("accepts an option object", () => {
       const subject = new ProperDate("2023-12-25");
-      expect(subject.subtract(1, { period: "day" })).toStrictEqual(new ProperDate("2023-12-24"));
-      expect(subject.subtract(2, { period: "months" })).toStrictEqual(new ProperDate("2023-10-25"));
-      expect(subject.subtract(10, { period: "years" })).toStrictEqual(new ProperDate("2013-12-25"));
+      expectEqualDates(subject.subtract(1, { period: "day" }), new ProperDate("2023-12-24"));
+      expectEqualDates(subject.subtract(2, { period: "months" }), new ProperDate("2023-10-25"));
+      expectEqualDates(subject.subtract(10, { period: "years" }), new ProperDate("2013-12-25"));
     });
   });
 
@@ -144,80 +145,36 @@ describe("model", () => {
   describe("#priorYearEnd", () => {
     test("returns a ProperDate for 12/31 of the prior year", () => {
       const subject = new ProperDate("2023-12-25");
-      expect(subject.priorYearEnd).toStrictEqual(new ProperDate("2022-12-31"));
+      expectEqualDates(subject.priorYearEnd, new ProperDate("2022-12-31"));
     });
   });
 
   describe("#priorMonthEnd", () => {
     test("returns a ProperDate for the end of the prior month", () => {
       const subject = new ProperDate("2023-12-25");
-      expect(subject.priorMonthEnd).toStrictEqual(new ProperDate("2023-11-30"));
+      expectEqualDates(subject.priorMonthEnd, new ProperDate("2023-11-30"));
     });
   });
 
   describe("#endOfMonth", () => {
     test("returns a ProperDate for the last day of the given month", () => {
-      expect(new ProperDate("2023-12-25").endOfMonth).toStrictEqual(new ProperDate("2023-12-31"));
-      expect(new ProperDate("2023-12-31").endOfMonth).toStrictEqual(new ProperDate("2023-12-31"));
-      expect(new ProperDate("2025-11-11").endOfMonth).toStrictEqual(new ProperDate("2025-11-30"));
+      expectEqualDates(new ProperDate("2023-12-25").endOfMonth, new ProperDate("2023-12-31"));
+      expectEqualDates(new ProperDate("2023-12-31").endOfMonth, new ProperDate("2023-12-31"));
+      expectEqualDates(new ProperDate("2025-11-11").endOfMonth, new ProperDate("2025-11-30"));
 
       // February
-      expect(new ProperDate("2024-02-01").endOfMonth).toStrictEqual(new ProperDate("2024-02-29"));
-      expect(new ProperDate("2023-02-01").endOfMonth).toStrictEqual(new ProperDate("2023-02-28"));
+      expectEqualDates(new ProperDate("2024-02-01").endOfMonth, new ProperDate("2024-02-29"));
+      expectEqualDates(new ProperDate("2023-02-01").endOfMonth, new ProperDate("2023-02-28"));
     });
   });
 
   describe("#endOfYear", () => {
     test("returns a ProperDate for 12/31 of the given year", () => {
-      expect(new ProperDate("2023-12-25").endOfYear).toStrictEqual(new ProperDate("2023-12-31"));
-      expect(new ProperDate("2023-12-31").endOfYear).toStrictEqual(new ProperDate("2023-12-31"));
-      expect(new ProperDate("2025-11-11").endOfYear).toStrictEqual(new ProperDate("2025-12-31"));
-      expect(new ProperDate("1981-01-01").endOfYear).toStrictEqual(new ProperDate("1981-12-31"));
-    });
-  });
-
-  describe("#getEndOfNMonthsAgo", () => {
-    test("returns a ProperDate for 12/31 of the prior year", () => {
-      const subject = new ProperDate("2023-12-25");
-
-      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-      subject.getEndOfNMonthsAgo(1);
-      expect(warnSpy).toHaveBeenCalledWith(
-        "DEPRECATION WARNING: getEndOfNMonthsAgo() is deprecated and will be removed in a future release. Use subtract(n, 'months').endOfMonth instead.",
-      );
-      warnSpy.mockRestore();
-
-      expect(subject.getEndOfNMonthsAgo(1)).toStrictEqual(new ProperDate("2023-11-30"));
-      expect(subject.getEndOfNMonthsAgo(2)).toStrictEqual(new ProperDate("2023-10-31"));
-      expect(subject.getEndOfNMonthsAgo(10)).toStrictEqual(new ProperDate("2023-02-28"));
-
-      const postLeapDay = new ProperDate("2024-03-01");
-      expect(postLeapDay.getEndOfNMonthsAgo(1)).toStrictEqual(new ProperDate("2024-02-29"));
-      expect(postLeapDay.getEndOfNMonthsAgo(13)).toStrictEqual(new ProperDate("2023-02-28"));
-
-      // new pattern
-      expect(subject.subtract(2, "months").endOfMonth).toStrictEqual(new ProperDate("2023-10-31"));
-      expect(postLeapDay.subtract(1, "months").endOfMonth).toStrictEqual(new ProperDate("2024-02-29"));
-    });
-  });
-
-  describe("#getEndOfNYearsAgo", () => {
-    test("returns a ProperDate for 12/31 of the prior year", () => {
-      const subject = new ProperDate("2023-12-25");
-
-      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-      subject.getEndOfNYearsAgo(1);
-      expect(warnSpy).toHaveBeenCalledWith(
-        "DEPRECATION WARNING: getEndOfNYearsAgo() is deprecated and will be removed in a future release. Use subtract(n, 'years').endOfYear instead.",
-      );
-      warnSpy.mockRestore();
-
-      expect(subject.getEndOfNYearsAgo(1)).toStrictEqual(new ProperDate("2022-12-31"));
-      expect(subject.getEndOfNYearsAgo(2)).toStrictEqual(new ProperDate("2021-12-31"));
-      expect(subject.getEndOfNYearsAgo(10)).toStrictEqual(new ProperDate("2013-12-31"));
-
-      // new pattern
-      expect(subject.subtract(2, "years").endOfYear).toStrictEqual(new ProperDate("2021-12-31"));
+      expectEqualDates(new ProperDate("2023-12-25").endOfYear, new ProperDate("2023-12-31"));
+      expectEqualDates(new ProperDate("2023-12-31").endOfYear, new ProperDate("2023-12-31"));
+      expectEqualDates(new ProperDate("2025-11-11").endOfYear, new ProperDate("2025-12-31"));
+      expectEqualDates(new ProperDate("1981-01-01").endOfYear, new ProperDate("1981-12-31"));
+      expectEqualDates(new ProperDate("1981-01-01").endOfYear, new ProperDate("1981-12-31"));
     });
   });
 });

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -66,7 +66,7 @@ describe("model", () => {
     test("returns true if the dates are equal", () => {
       const subject = new ProperDate("2023-12-25");
 
-      expectEqualDates(subject, new ProperDate("2023-12-25"))
+      expectEqualDates(subject, new ProperDate("2023-12-25"));
       expect(subject.equals(new ProperDate(new Date("2023-12-25")))).toStrictEqual(true);
       expect(subject.equals(new ProperDate(new Date(Date.UTC(2023, 11, 25))))).toStrictEqual(true);
     });

--- a/tests/support/matchers.ts
+++ b/tests/support/matchers.ts
@@ -1,9 +1,9 @@
-import ProperDate from "../../lib";
+import type ProperDate from "../../lib";
 
 export const expectEqualDates = (actual: ProperDate, expected: ProperDate) => {
   try {
     expect(actual.equals(expected)).toBe(true);
-  } catch (error) {
+  } catch (_error) {
     throw new Error(`Expected ${actual.toString()} to equal ${expected.toString()}`);
   }
 };

--- a/tests/support/matchers.ts
+++ b/tests/support/matchers.ts
@@ -1,0 +1,9 @@
+import ProperDate from "../../lib";
+
+export const expectEqualDates = (actual: ProperDate, expected: ProperDate) => {
+  try {
+    expect(actual.equals(expected)).toBe(true);
+  } catch (error) {
+    throw new Error(`Expected ${actual.toString()} to equal ${expected.toString()}`);
+  }
+};

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -18,6 +18,23 @@ describe("utils", () => {
       expect(result.day).toStrictEqual(25);
     });
 
+    test("with a [year, month, day] array", () => {
+      let result = parseInput([2023, 12, 25]);
+      expect(result.year).toStrictEqual(2023);
+      expect(result.month).toStrictEqual(11);
+      expect(result.day).toStrictEqual(25);
+
+      result = parseInput([2023, 1, 25]);
+      expect(result.year).toStrictEqual(2023);
+      expect(result.month).toStrictEqual(0);
+      expect(result.day).toStrictEqual(25);
+
+      result = parseInput([2023, 0, 25]);
+      expect(result.year).toStrictEqual(2022);
+      expect(result.month).toStrictEqual(11);
+      expect(result.day).toStrictEqual(25);
+    });
+
     describe("with a JavaScript date, without a specific timezone", () => {
       test("when constructed from a string", () => {
         const date = new Date("2023-12-25");

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,7 +1,35 @@
 import ProperDate from "../lib";
-import { parseInput } from "../lib/utils";
+import { buildUtcDate, parseInput } from "../lib/utils";
 
 describe("utils", () => {
+
+  describe("buildUtcDate", () => {
+    test("returns a UTC date", () => {
+      expect(buildUtcDate(2023, 12, 25)).toStrictEqual(new Date("2023-12-25T00:00:00.000Z"));
+      expect(buildUtcDate(2023, 12, 26)).toStrictEqual(new Date("2023-12-26T00:00:00.000Z"));
+      expect(buildUtcDate(2023, 12, 31)).toStrictEqual(new Date("2023-12-31T00:00:00.000Z"));
+
+      expect(buildUtcDate(2024, 2, 28)).toStrictEqual(new Date("2024-02-28T00:00:00.000Z"));
+      expect(buildUtcDate(2024, 2, 29)).toStrictEqual(new Date("2024-02-29T00:00:00.000Z"));
+      expect(buildUtcDate(2024, 3, 1)).toStrictEqual(new Date("2024-03-01T00:00:00.000Z"));
+    });
+
+    test("handles day wrapping", () => {
+      expect(buildUtcDate(2023, 2, 35)).toStrictEqual(new Date("2023-03-07T00:00:00.000Z"));
+      expect(buildUtcDate(2024, 1, 15 + 366)).toStrictEqual(new Date("2025-01-15T00:00:00.000Z"));
+    });
+
+    test("handles month wrapping", () => {
+      expect(buildUtcDate(2023, 13, 2)).toStrictEqual(new Date("2024-01-02:00:00.000Z"));
+      expect(buildUtcDate(2024, 0, 2)).toStrictEqual(new Date("2023-12-02:00:00.000Z"));
+    });
+
+    test("handles end of month utilities", () => {
+      expect(buildUtcDate(2023, 12, 0)).toStrictEqual(new Date("2023-11-30:00:00.000Z"));
+      expect(buildUtcDate(2024, 3, 0)).toStrictEqual(new Date("2024-02-29:00:00.000Z"));
+    });
+  });
+    
   describe("parseInput", () => {
     test("with a ProperDate", () => {
       const input = new ProperDate("2023-12-25");

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -2,7 +2,6 @@ import ProperDate from "../lib";
 import { buildUtcDate, parseInput } from "../lib/utils";
 
 describe("utils", () => {
-
   describe("buildUtcDate", () => {
     test("returns a UTC date", () => {
       expect(buildUtcDate(2023, 12, 25)).toStrictEqual(new Date("2023-12-25T00:00:00.000Z"));
@@ -29,7 +28,7 @@ describe("utils", () => {
       expect(buildUtcDate(2024, 3, 0)).toStrictEqual(new Date("2024-02-29:00:00.000Z"));
     });
   });
-    
+
   describe("parseInput", () => {
     test("with a ProperDate", () => {
       const input = new ProperDate("2023-12-25");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ProperDate now supports undefined input, defaulting to the current date.
  * Added a getter for one-based month indexing (actualMonth).
  * Utility functions introduced for consistent UTC date creation and parsing.
  * parseInput now accepts [year, month, day] arrays.

* **Bug Fixes**
  * Standardized date parsing and construction to UTC across all date operations.

* **Tests**
  * Expanded test coverage for UTC date utilities and new input formats.
  * Introduced a custom matcher for clearer date equality assertions.
  * Removed deprecated tests for obsolete methods.

* **Refactor**
  * Unified date creation logic across the codebase for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->