### PR TITLE
fix: Use local timezone to avoid differences in output

### DIFF
--- a/lib/arithmetic.ts
+++ b/lib/arithmetic.ts
@@ -1,6 +1,6 @@
 import ProperDate from "./model";
 import type { ArithmeticOptions } from "./types";
-import { buildUtcDate } from "./utils";
+import { buildDate } from "./utils";
 
 const DEFAULT_OPTIONS: ArithmeticOptions = { period: "days" };
 
@@ -15,12 +15,12 @@ export const add = (base: ProperDate, n: number, options: ArithmeticOptions = DE
 
   if (period === "day" || period === "days") {
     const baseDate = base.toDate();
-    const newDate = buildUtcDate(baseDate.getFullYear(), baseDate.getMonth() + 1, baseDate.getDate() + n);
+    const newDate = buildDate(baseDate.getFullYear(), baseDate.getMonth() + 1, baseDate.getDate() + n);
     return new ProperDate(newDate);
   }
   if (period === "month" || period === "months") {
     const baseDate = base.toDate();
-    const targetDate = buildUtcDate(baseDate.getFullYear(), baseDate.getMonth() + 1 + n, baseDate.getDate());
+    const targetDate = buildDate(baseDate.getFullYear(), baseDate.getMonth() + 1 + n, baseDate.getDate());
 
     // Handle cases where the target date overflows to the next month
     // // Calculate expected month: original month + n, then take modulo 12
@@ -33,7 +33,7 @@ export const add = (base: ProperDate, n: number, options: ArithmeticOptions = DE
   }
   if (period === "year" || period === "years") {
     const baseDate = base.toDate();
-    return new ProperDate(new Date(Date.UTC(baseDate.getFullYear() + n, baseDate.getMonth(), baseDate.getDate())));
+    return new ProperDate(new Date(baseDate.getFullYear() + n, baseDate.getMonth(), baseDate.getDate()));
   }
 
   throw new Error(`Period '${period}' is not supported`);

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -1,6 +1,6 @@
 import { add, difference, subtract } from "./arithmetic";
 import type { ArithmeticOptions, Period } from "./types";
-import { buildUtcDate, parseInput } from "./utils";
+import { buildDate, parseInput } from "./utils";
 
 const getDefaultDate = (): string => {
   return new Date().toISOString().split("T")[0];
@@ -39,11 +39,11 @@ export default class ProperDate {
   }
 
   get endOfMonth(): ProperDate {
-    return new ProperDate(buildUtcDate(this.year, this.actualMonth + 1, 0));
+    return new ProperDate(buildDate(this.year, this.actualMonth + 1, 0));
   }
 
   get endOfYear(): ProperDate {
-    return new ProperDate(buildUtcDate(this.year, 12, 31));
+    return new ProperDate(buildDate(this.year, 12, 31));
   }
 
   equals(other: ProperDate): boolean {
@@ -110,6 +110,6 @@ export default class ProperDate {
   }
 
   private get jsDate(): Date {
-    return buildUtcDate(this.year, this.actualMonth, this.day);
+    return buildDate(this.year, this.actualMonth, this.day);
   }
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,12 +1,16 @@
 import ProperDate from "./model";
 
-export const buildUtcDate = (year: number, month: number, day: number): Date => {
-  return new Date(Date.UTC(year, month - 1, day));
+export const buildDate = (year: number, month: number, day: number): Date => {
+  return new Date(year, month - 1, day);
 };
 
-export const buildUtcDateFromString = (value: string): Date => {
+export const buildDateFromString = (value: string): Date => {
   const [year, month, day] = value.split("-").map(Number);
-  return buildUtcDate(year, month, day);
+  return buildDate(year, month, day);
+};
+
+export const normalizeDate = (date: Date): Date => {
+  return buildDateFromString(date.toISOString().split("T")[0]);
 };
 
 export const parseInput = (date: ProperDate | Date | string | number[]) => {
@@ -19,16 +23,17 @@ export const parseInput = (date: ProperDate | Date | string | number[]) => {
     month = date.month;
     day = date.day;
   } else if (date instanceof Date) {
-    year = date.getFullYear();
-    month = date.getMonth();
-    day = date.getDate();
+    const parsedDate = normalizeDate(date);
+    year = parsedDate.getFullYear();
+    month = parsedDate.getMonth();
+    day = parsedDate.getDate();
   } else if (Array.isArray(date) && date.length === 3) {
-    const parsedDate = buildUtcDate(date[0], date[1], date[2]);
+    const parsedDate = buildDate(date[0], date[1], date[2]);
     year = parsedDate.getFullYear();
     month = parsedDate.getMonth();
     day = parsedDate.getDate();
   } else if (typeof date === "string" && isValidDateFormat(date)) {
-    const parsedDate = buildUtcDateFromString(date);
+    const parsedDate = buildDateFromString(date);
     year = parsedDate.getFullYear();
     month = parsedDate.getMonth();
     day = parsedDate.getDate();
@@ -47,7 +52,7 @@ function isValidDateFormat(dateString: string): boolean {
   }
 
   // Further validate the date is real
-  const date = buildUtcDateFromString(dateString);
+  const date = buildDateFromString(dateString);
   const [year, month, day] = dateString.split("-").map(Number);
 
   return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;

--- a/tests/arithmetic.test.ts
+++ b/tests/arithmetic.test.ts
@@ -1,91 +1,91 @@
 import ProperDate from "../lib";
 import { add, difference, subtract } from "../lib/arithmetic";
-import { expectEqualDates } from "./support/matchers";
+import { expectEqualProperDates } from "./support/matchers";
 
 describe("arithmetic", () => {
   // TODO: Review these results, particularly months-related logic: https://github.com/still-forest/proper-date.js/issues/22
   describe("add", () => {
     test("by default, returns ProperDate with days added", () => {
       const base = new ProperDate("2023-12-25");
-      expectEqualDates(add(base, 1), new ProperDate("2023-12-26"));
-      expectEqualDates(add(base, 2), new ProperDate("2023-12-27"));
-      expectEqualDates(add(base, 10), new ProperDate("2024-01-04"));
-      expectEqualDates(add(base, 365), new ProperDate("2024-12-24"));
+      expectEqualProperDates(add(base, 1), new ProperDate("2023-12-26"));
+      expectEqualProperDates(add(base, 2), new ProperDate("2023-12-27"));
+      expectEqualProperDates(add(base, 10), new ProperDate("2024-01-04"));
+      expectEqualProperDates(add(base, 365), new ProperDate("2024-12-24"));
     });
 
     test("with days, returns ProperDate with days added", () => {
       const base = new ProperDate("2023-12-25");
-      expectEqualDates(add(base, 1, { period: "day" }), new ProperDate("2023-12-26"));
-      expectEqualDates(add(base, 2, { period: "days" }), new ProperDate("2023-12-27"));
-      expectEqualDates(add(base, 10, { period: "days" }), new ProperDate("2024-01-04"));
-      expectEqualDates(add(base, 365, { period: "days" }), new ProperDate("2024-12-24"));
+      expectEqualProperDates(add(base, 1, { period: "day" }), new ProperDate("2023-12-26"));
+      expectEqualProperDates(add(base, 2, { period: "days" }), new ProperDate("2023-12-27"));
+      expectEqualProperDates(add(base, 10, { period: "days" }), new ProperDate("2024-01-04"));
+      expectEqualProperDates(add(base, 365, { period: "days" }), new ProperDate("2024-12-24"));
     });
 
     test("with months, returns ProperDate with months added", () => {
       const base = new ProperDate("2023-12-25");
-      expectEqualDates(add(base, 1, { period: "month" }), new ProperDate("2024-01-25"));
-      expectEqualDates(add(base, 2, { period: "months" }), new ProperDate("2024-02-25"));
-      expectEqualDates(add(base, 10, { period: "months" }), new ProperDate("2024-10-25"));
-      expectEqualDates(add(base, 120, { period: "months" }), new ProperDate("2033-12-25"));
+      expectEqualProperDates(add(base, 1, { period: "month" }), new ProperDate("2024-01-25"));
+      expectEqualProperDates(add(base, 2, { period: "months" }), new ProperDate("2024-02-25"));
+      expectEqualProperDates(add(base, 10, { period: "months" }), new ProperDate("2024-10-25"));
+      expectEqualProperDates(add(base, 120, { period: "months" }), new ProperDate("2033-12-25"));
     });
 
     test("with months, overlaps months properly", () => {
       const base = new ProperDate("2023-01-31");
-      expectEqualDates(add(base, 1, { period: "month" }), new ProperDate("2023-02-28"));
-      expectEqualDates(add(base, 13, { period: "months" }), new ProperDate("2024-02-29"));
+      expectEqualProperDates(add(base, 1, { period: "month" }), new ProperDate("2023-02-28"));
+      expectEqualProperDates(add(base, 13, { period: "months" }), new ProperDate("2024-02-29"));
 
       const thirtyDayMonth = new ProperDate("2023-04-30");
-      expectEqualDates(add(thirtyDayMonth, 1, { period: "month" }), new ProperDate("2023-05-30"));
+      expectEqualProperDates(add(thirtyDayMonth, 1, { period: "month" }), new ProperDate("2023-05-30"));
     });
 
     test("with years, returns ProperDate with years added", () => {
       const base = new ProperDate("2023-12-25");
-      expectEqualDates(add(base, 1, { period: "year" }), new ProperDate("2024-12-25"));
-      expectEqualDates(add(base, 2, { period: "years" }), new ProperDate("2025-12-25"));
-      expectEqualDates(add(base, 10, { period: "years" }), new ProperDate("2033-12-25"));
-      expectEqualDates(add(base, 120, { period: "years" }), new ProperDate("2143-12-25"));
+      expectEqualProperDates(add(base, 1, { period: "year" }), new ProperDate("2024-12-25"));
+      expectEqualProperDates(add(base, 2, { period: "years" }), new ProperDate("2025-12-25"));
+      expectEqualProperDates(add(base, 10, { period: "years" }), new ProperDate("2033-12-25"));
+      expectEqualProperDates(add(base, 120, { period: "years" }), new ProperDate("2143-12-25"));
     });
 
     // TODO: Review this leap year handling: https://github.com/still-forest/proper-date.js/issues/23
     test("leap day as base handling", () => {
       const leapDay = new ProperDate("2020-02-29");
 
-      expectEqualDates(add(leapDay, 1, { period: "day" }), new ProperDate("2020-03-01"));
-      expectEqualDates(add(leapDay, 365, { period: "days" }), new ProperDate("2021-02-28"));
-      expectEqualDates(add(leapDay, 1461, { period: "days" }), new ProperDate("2024-02-29"));
+      expectEqualProperDates(add(leapDay, 1, { period: "day" }), new ProperDate("2020-03-01"));
+      expectEqualProperDates(add(leapDay, 365, { period: "days" }), new ProperDate("2021-02-28"));
+      expectEqualProperDates(add(leapDay, 1461, { period: "days" }), new ProperDate("2024-02-29"));
 
-      expectEqualDates(add(leapDay, 1, { period: "month" }), new ProperDate("2020-03-29"));
-      expectEqualDates(add(leapDay, 12, { period: "months" }), new ProperDate("2021-02-28"));
-      expectEqualDates(add(leapDay, 48, { period: "months" }), new ProperDate("2024-02-29"));
-      expectEqualDates(add(leapDay, 60, { period: "months" }), new ProperDate("2025-02-28"));
+      expectEqualProperDates(add(leapDay, 1, { period: "month" }), new ProperDate("2020-03-29"));
+      expectEqualProperDates(add(leapDay, 12, { period: "months" }), new ProperDate("2021-02-28"));
+      expectEqualProperDates(add(leapDay, 48, { period: "months" }), new ProperDate("2024-02-29"));
+      expectEqualProperDates(add(leapDay, 60, { period: "months" }), new ProperDate("2025-02-28"));
 
-      expectEqualDates(add(leapDay, 1, { period: "year" }), new ProperDate("2021-03-01"));
-      expectEqualDates(add(leapDay, 4, { period: "years" }), new ProperDate("2024-02-29"));
-      expectEqualDates(add(leapDay, 5, { period: "years" }), new ProperDate("2025-03-01"));
+      expectEqualProperDates(add(leapDay, 1, { period: "year" }), new ProperDate("2021-03-01"));
+      expectEqualProperDates(add(leapDay, 4, { period: "years" }), new ProperDate("2024-02-29"));
+      expectEqualProperDates(add(leapDay, 5, { period: "years" }), new ProperDate("2025-03-01"));
     });
 
     test("leap year as result handling", () => {
       const dayBeforeLeapDay = new ProperDate("2020-02-28");
       const monthBeforeLeapDay = new ProperDate("2020-01-30");
 
-      expectEqualDates(add(dayBeforeLeapDay, 1, { period: "day" }), new ProperDate("2020-02-29"));
+      expectEqualProperDates(add(dayBeforeLeapDay, 1, { period: "day" }), new ProperDate("2020-02-29"));
 
-      expectEqualDates(add(monthBeforeLeapDay, 1, { period: "month" }), new ProperDate("2020-02-29"));
-      expectEqualDates(add(monthBeforeLeapDay, 13, { period: "months" }), new ProperDate("2021-02-28"));
-      expectEqualDates(add(monthBeforeLeapDay, 49, { period: "months" }), new ProperDate("2024-02-29"));
-      expectEqualDates(add(monthBeforeLeapDay, 61, { period: "months" }), new ProperDate("2025-02-28"));
+      expectEqualProperDates(add(monthBeforeLeapDay, 1, { period: "month" }), new ProperDate("2020-02-29"));
+      expectEqualProperDates(add(monthBeforeLeapDay, 13, { period: "months" }), new ProperDate("2021-02-28"));
+      expectEqualProperDates(add(monthBeforeLeapDay, 49, { period: "months" }), new ProperDate("2024-02-29"));
+      expectEqualProperDates(add(monthBeforeLeapDay, 61, { period: "months" }), new ProperDate("2025-02-28"));
     });
 
     test("with zero and negative values", () => {
       const base = new ProperDate("2023-12-25");
 
-      expectEqualDates(add(base, 0, { period: "days" }), base);
-      expectEqualDates(add(base, 0, { period: "months" }), base);
-      expectEqualDates(add(base, 0, { period: "years" }), base);
+      expectEqualProperDates(add(base, 0, { period: "days" }), base);
+      expectEqualProperDates(add(base, 0, { period: "months" }), base);
+      expectEqualProperDates(add(base, 0, { period: "years" }), base);
 
-      expectEqualDates(add(base, -1, { period: "days" }), new ProperDate("2023-12-24"));
-      expectEqualDates(add(base, -1, { period: "months" }), new ProperDate("2023-11-25"));
-      expectEqualDates(add(base, -1, { period: "year" }), new ProperDate("2022-12-25"));
+      expectEqualProperDates(add(base, -1, { period: "days" }), new ProperDate("2023-12-24"));
+      expectEqualProperDates(add(base, -1, { period: "months" }), new ProperDate("2023-11-25"));
+      expectEqualProperDates(add(base, -1, { period: "year" }), new ProperDate("2022-12-25"));
     });
 
     test("throws error for unsupported period", () => {
@@ -101,85 +101,85 @@ describe("arithmetic", () => {
   describe("subtract", () => {
     test("by default, returns ProperDate with days subtracted", () => {
       const base = new ProperDate("2023-12-25");
-      expectEqualDates(subtract(base, 1), new ProperDate("2023-12-24"));
-      expectEqualDates(subtract(base, 2), new ProperDate("2023-12-23"));
-      expectEqualDates(subtract(base, 10), new ProperDate("2023-12-15"));
-      expectEqualDates(subtract(base, 365), new ProperDate("2022-12-25"));
+      expectEqualProperDates(subtract(base, 1), new ProperDate("2023-12-24"));
+      expectEqualProperDates(subtract(base, 2), new ProperDate("2023-12-23"));
+      expectEqualProperDates(subtract(base, 10), new ProperDate("2023-12-15"));
+      expectEqualProperDates(subtract(base, 365), new ProperDate("2022-12-25"));
     });
 
     test("with days, returns ProperDate with days subtracted", () => {
       const base = new ProperDate("2023-12-25");
-      expectEqualDates(subtract(base, 1, { period: "day" }), new ProperDate("2023-12-24"));
-      expectEqualDates(subtract(base, 2, { period: "days" }), new ProperDate("2023-12-23"));
-      expectEqualDates(subtract(base, 10, { period: "days" }), new ProperDate("2023-12-15"));
-      expectEqualDates(subtract(base, 365, { period: "days" }), new ProperDate("2022-12-25"));
+      expectEqualProperDates(subtract(base, 1, { period: "day" }), new ProperDate("2023-12-24"));
+      expectEqualProperDates(subtract(base, 2, { period: "days" }), new ProperDate("2023-12-23"));
+      expectEqualProperDates(subtract(base, 10, { period: "days" }), new ProperDate("2023-12-15"));
+      expectEqualProperDates(subtract(base, 365, { period: "days" }), new ProperDate("2022-12-25"));
     });
 
     test("with months, returns ProperDate with months subtracted", () => {
       const base = new ProperDate("2023-12-25");
-      expectEqualDates(subtract(base, 1, { period: "month" }), new ProperDate("2023-11-25"));
-      expectEqualDates(subtract(base, 2, { period: "months" }), new ProperDate("2023-10-25"));
-      expectEqualDates(subtract(base, 10, { period: "months" }), new ProperDate("2023-02-25"));
-      expectEqualDates(subtract(base, 120, { period: "months" }), new ProperDate("2013-12-25"));
+      expectEqualProperDates(subtract(base, 1, { period: "month" }), new ProperDate("2023-11-25"));
+      expectEqualProperDates(subtract(base, 2, { period: "months" }), new ProperDate("2023-10-25"));
+      expectEqualProperDates(subtract(base, 10, { period: "months" }), new ProperDate("2023-02-25"));
+      expectEqualProperDates(subtract(base, 120, { period: "months" }), new ProperDate("2013-12-25"));
     });
 
     test("with months, overlaps months properly", () => {
       const base = new ProperDate("2023-03-31");
-      expectEqualDates(subtract(base, 1, { period: "month" }), new ProperDate("2023-02-28"));
-      expectEqualDates(subtract(base, 13, { period: "months" }), new ProperDate("2022-02-28"));
+      expectEqualProperDates(subtract(base, 1, { period: "month" }), new ProperDate("2023-02-28"));
+      expectEqualProperDates(subtract(base, 13, { period: "months" }), new ProperDate("2022-02-28"));
 
       const thirtyDayMonth = new ProperDate("2023-04-30");
-      expectEqualDates(subtract(thirtyDayMonth, 1, { period: "month" }), new ProperDate("2023-03-30"));
+      expectEqualProperDates(subtract(thirtyDayMonth, 1, { period: "month" }), new ProperDate("2023-03-30"));
     });
 
     test("with years, returns ProperDate with years subtracted", () => {
       const base = new ProperDate("2023-12-25");
-      expectEqualDates(subtract(base, 1, { period: "year" }), new ProperDate("2022-12-25"));
-      expectEqualDates(subtract(base, 2, { period: "years" }), new ProperDate("2021-12-25"));
-      expectEqualDates(subtract(base, 10, { period: "years" }), new ProperDate("2013-12-25"));
-      expectEqualDates(subtract(base, 120, { period: "years" }), new ProperDate("1903-12-25"));
+      expectEqualProperDates(subtract(base, 1, { period: "year" }), new ProperDate("2022-12-25"));
+      expectEqualProperDates(subtract(base, 2, { period: "years" }), new ProperDate("2021-12-25"));
+      expectEqualProperDates(subtract(base, 10, { period: "years" }), new ProperDate("2013-12-25"));
+      expectEqualProperDates(subtract(base, 120, { period: "years" }), new ProperDate("1903-12-25"));
     });
 
     // TODO: Review this leap year handling: https://github.com/still-forest/proper-date.js/issues/23
     test("leap day as base handling", () => {
       const leapDay = new ProperDate("2020-02-29");
 
-      expectEqualDates(subtract(leapDay, 1, { period: "day" }), new ProperDate("2020-02-28"));
-      expectEqualDates(subtract(leapDay, 365, { period: "days" }), new ProperDate("2019-03-01"));
-      expectEqualDates(subtract(leapDay, 1461, { period: "days" }), new ProperDate("2016-02-29"));
+      expectEqualProperDates(subtract(leapDay, 1, { period: "day" }), new ProperDate("2020-02-28"));
+      expectEqualProperDates(subtract(leapDay, 365, { period: "days" }), new ProperDate("2019-03-01"));
+      expectEqualProperDates(subtract(leapDay, 1461, { period: "days" }), new ProperDate("2016-02-29"));
 
-      expectEqualDates(subtract(leapDay, 1, { period: "month" }), new ProperDate("2020-01-29"));
-      expectEqualDates(subtract(leapDay, 12, { period: "months" }), new ProperDate("2019-02-28"));
-      expectEqualDates(subtract(leapDay, 48, { period: "months" }), new ProperDate("2016-02-29"));
-      expectEqualDates(subtract(leapDay, 60, { period: "months" }), new ProperDate("2015-02-28"));
+      expectEqualProperDates(subtract(leapDay, 1, { period: "month" }), new ProperDate("2020-01-29"));
+      expectEqualProperDates(subtract(leapDay, 12, { period: "months" }), new ProperDate("2019-02-28"));
+      expectEqualProperDates(subtract(leapDay, 48, { period: "months" }), new ProperDate("2016-02-29"));
+      expectEqualProperDates(subtract(leapDay, 60, { period: "months" }), new ProperDate("2015-02-28"));
 
-      expectEqualDates(subtract(leapDay, 1, { period: "year" }), new ProperDate("2019-03-01"));
-      expectEqualDates(subtract(leapDay, 4, { period: "years" }), new ProperDate("2016-02-29"));
-      expectEqualDates(subtract(leapDay, 5, { period: "years" }), new ProperDate("2015-03-01"));
+      expectEqualProperDates(subtract(leapDay, 1, { period: "year" }), new ProperDate("2019-03-01"));
+      expectEqualProperDates(subtract(leapDay, 4, { period: "years" }), new ProperDate("2016-02-29"));
+      expectEqualProperDates(subtract(leapDay, 5, { period: "years" }), new ProperDate("2015-03-01"));
     });
 
     test("leap year as result handling", () => {
       const dayAfterLeapDay = new ProperDate("2020-03-01");
       const monthAfterLeapDay = new ProperDate("2020-03-29");
 
-      expectEqualDates(subtract(dayAfterLeapDay, 1, { period: "day" }), new ProperDate("2020-02-29"));
+      expectEqualProperDates(subtract(dayAfterLeapDay, 1, { period: "day" }), new ProperDate("2020-02-29"));
 
-      expectEqualDates(subtract(monthAfterLeapDay, 1, { period: "month" }), new ProperDate("2020-02-29"));
-      expectEqualDates(subtract(monthAfterLeapDay, 13, { period: "months" }), new ProperDate("2019-02-28"));
-      expectEqualDates(subtract(monthAfterLeapDay, 49, { period: "months" }), new ProperDate("2016-02-29"));
-      expectEqualDates(subtract(monthAfterLeapDay, 61, { period: "months" }), new ProperDate("2015-02-28"));
+      expectEqualProperDates(subtract(monthAfterLeapDay, 1, { period: "month" }), new ProperDate("2020-02-29"));
+      expectEqualProperDates(subtract(monthAfterLeapDay, 13, { period: "months" }), new ProperDate("2019-02-28"));
+      expectEqualProperDates(subtract(monthAfterLeapDay, 49, { period: "months" }), new ProperDate("2016-02-29"));
+      expectEqualProperDates(subtract(monthAfterLeapDay, 61, { period: "months" }), new ProperDate("2015-02-28"));
     });
 
     test("with zero and negative values", () => {
       const base = new ProperDate("2023-12-25");
 
-      expectEqualDates(subtract(base, 0, { period: "days" }), base);
-      expectEqualDates(subtract(base, 0, { period: "months" }), base);
-      expectEqualDates(subtract(base, 0, { period: "years" }), base);
+      expectEqualProperDates(subtract(base, 0, { period: "days" }), base);
+      expectEqualProperDates(subtract(base, 0, { period: "months" }), base);
+      expectEqualProperDates(subtract(base, 0, { period: "years" }), base);
 
-      expectEqualDates(subtract(base, -1, { period: "days" }), new ProperDate("2023-12-26"));
-      expectEqualDates(subtract(base, -1, { period: "months" }), new ProperDate("2024-01-25"));
-      expectEqualDates(subtract(base, -1, { period: "year" }), new ProperDate("2024-12-25"));
+      expectEqualProperDates(subtract(base, -1, { period: "days" }), new ProperDate("2023-12-26"));
+      expectEqualProperDates(subtract(base, -1, { period: "months" }), new ProperDate("2024-01-25"));
+      expectEqualProperDates(subtract(base, -1, { period: "year" }), new ProperDate("2024-12-25"));
     });
 
     test("throws error for unsupported period", () => {

--- a/tests/factory.test.ts
+++ b/tests/factory.test.ts
@@ -1,6 +1,6 @@
 import { getToday, getYesterday } from "../lib/factory";
 import ProperDate from "../lib/model";
-import { expectEqualDates } from "./support/matchers";
+import { expectEqualProperDates } from "./support/matchers";
 
 describe("factory", () => {
   beforeEach(() => {
@@ -15,14 +15,14 @@ describe("factory", () => {
   describe("today", () => {
     test("returns a ProperDate instance for today's date", () => {
       const subject = getToday();
-      expectEqualDates(subject, new ProperDate("2025-01-02"));
+      expectEqualProperDates(subject, new ProperDate("2025-01-02"));
     });
   });
 
   describe("yesterday", () => {
     test("returns a ProperDate instance for yesterday's date", () => {
       const subject = getYesterday();
-      expectEqualDates(subject, new ProperDate("2025-01-01"));
+      expectEqualProperDates(subject, new ProperDate("2025-01-01"));
     });
   });
 });

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -1,12 +1,12 @@
 import ProperDate from "../lib";
-import { expectEqualDates } from "./support/matchers";
+import { expectEqualDates, expectEqualProperDates } from "./support/matchers";
 
 describe("model", () => {
   describe("constructor", () => {
     test("with a yyyy-mm-dd formatted string", () => {
       const subject = new ProperDate("2023-12-25");
       expect(subject.toString()).toStrictEqual("2023-12-25");
-      expect(subject.toDate()).toStrictEqual(new Date("2023-12-25T00:00:00.000Z"));
+      expectEqualDates(subject.toDate(), new Date("2023-12-25T00:00:00.000Z"));
       expect(subject.year).toStrictEqual(2023);
       expect(subject.month).toStrictEqual(11);
       expect(subject.day).toStrictEqual(25);
@@ -16,7 +16,7 @@ describe("model", () => {
       const date = new Date("2023-12-25");
       const subject = new ProperDate(date);
       expect(subject.toString()).toStrictEqual("2023-12-25");
-      expect(subject.toDate()).toStrictEqual(new Date("2023-12-25T00:00:00.000Z"));
+      expectEqualDates(subject.toDate(), new Date("2023-12-25T00:00:00.000Z"));
       expect(subject.year).toStrictEqual(2023);
       expect(subject.month).toStrictEqual(11);
       expect(subject.day).toStrictEqual(25);
@@ -26,7 +26,7 @@ describe("model", () => {
       const properDate = new ProperDate("2023-12-25");
       const subject = new ProperDate(properDate);
       expect(subject.toString()).toStrictEqual("2023-12-25");
-      expect(subject.toDate()).toStrictEqual(new Date("2023-12-25T00:00:00.000Z"));
+      expectEqualDates(subject.toDate(), new Date("2023-12-25T00:00:00.000Z"));
       expect(subject.year).toStrictEqual(2023);
       expect(subject.month).toStrictEqual(11);
       expect(subject.day).toStrictEqual(25);
@@ -65,10 +65,9 @@ describe("model", () => {
   describe("#equals", () => {
     test("returns true if the dates are equal", () => {
       const subject = new ProperDate("2023-12-25");
-
-      expectEqualDates(subject, new ProperDate("2023-12-25"));
-      expect(subject.equals(new ProperDate(new Date("2023-12-25")))).toStrictEqual(true);
-      expect(subject.equals(new ProperDate(new Date(Date.UTC(2023, 11, 25))))).toStrictEqual(true);
+      expect(subject.equals(new ProperDate("2023-12-25"))).toBe(true);
+      expect(subject.equals(new ProperDate(new Date("2023-12-25")))).toBe(true);
+      expect(subject.equals(new ProperDate(new Date(Date.UTC(2023, 11, 25))))).toBe(true);
     });
 
     test("returns false when the dates are not equal", () => {
@@ -96,32 +95,32 @@ describe("model", () => {
   describe("#add", () => {
     test("adds days, months, or years to the date, returning a new ProperDate", () => {
       const subject = new ProperDate("2023-12-25");
-      expectEqualDates(subject.add(1, "day"), new ProperDate("2023-12-26"));
-      expectEqualDates(subject.add(2, "months"), new ProperDate("2024-02-25"));
-      expectEqualDates(subject.add(10, "years"), new ProperDate("2033-12-25"));
+      expectEqualProperDates(subject.add(1, "day"), new ProperDate("2023-12-26"));
+      expectEqualProperDates(subject.add(2, "months"), new ProperDate("2024-02-25"));
+      expectEqualProperDates(subject.add(10, "years"), new ProperDate("2033-12-25"));
     });
 
     test("accepts an option object", () => {
       const subject = new ProperDate("2023-12-25");
-      expectEqualDates(subject.add(1, { period: "day" }), new ProperDate("2023-12-26"));
-      expectEqualDates(subject.add(2, { period: "months" }), new ProperDate("2024-02-25"));
-      expectEqualDates(subject.add(10, { period: "years" }), new ProperDate("2033-12-25"));
+      expectEqualProperDates(subject.add(1, { period: "day" }), new ProperDate("2023-12-26"));
+      expectEqualProperDates(subject.add(2, { period: "months" }), new ProperDate("2024-02-25"));
+      expectEqualProperDates(subject.add(10, { period: "years" }), new ProperDate("2033-12-25"));
     });
   });
 
   describe("#subtract", () => {
     test("subtracts days, months, or years to the date, returning a new ProperDate", () => {
       const subject = new ProperDate("2023-12-25");
-      expectEqualDates(subject.subtract(1, "day"), new ProperDate("2023-12-24"));
-      expectEqualDates(subject.subtract(2, "months"), new ProperDate("2023-10-25"));
-      expectEqualDates(subject.subtract(10, "years"), new ProperDate("2013-12-25"));
+      expectEqualProperDates(subject.subtract(1, "day"), new ProperDate("2023-12-24"));
+      expectEqualProperDates(subject.subtract(2, "months"), new ProperDate("2023-10-25"));
+      expectEqualProperDates(subject.subtract(10, "years"), new ProperDate("2013-12-25"));
     });
 
     test("accepts an option object", () => {
       const subject = new ProperDate("2023-12-25");
-      expectEqualDates(subject.subtract(1, { period: "day" }), new ProperDate("2023-12-24"));
-      expectEqualDates(subject.subtract(2, { period: "months" }), new ProperDate("2023-10-25"));
-      expectEqualDates(subject.subtract(10, { period: "years" }), new ProperDate("2013-12-25"));
+      expectEqualProperDates(subject.subtract(1, { period: "day" }), new ProperDate("2023-12-24"));
+      expectEqualProperDates(subject.subtract(2, { period: "months" }), new ProperDate("2023-10-25"));
+      expectEqualProperDates(subject.subtract(10, { period: "years" }), new ProperDate("2013-12-25"));
     });
   });
 
@@ -145,36 +144,36 @@ describe("model", () => {
   describe("#priorYearEnd", () => {
     test("returns a ProperDate for 12/31 of the prior year", () => {
       const subject = new ProperDate("2023-12-25");
-      expectEqualDates(subject.priorYearEnd, new ProperDate("2022-12-31"));
+      expectEqualProperDates(subject.priorYearEnd, new ProperDate("2022-12-31"));
     });
   });
 
   describe("#priorMonthEnd", () => {
     test("returns a ProperDate for the end of the prior month", () => {
       const subject = new ProperDate("2023-12-25");
-      expectEqualDates(subject.priorMonthEnd, new ProperDate("2023-11-30"));
+      expectEqualProperDates(subject.priorMonthEnd, new ProperDate("2023-11-30"));
     });
   });
 
   describe("#endOfMonth", () => {
     test("returns a ProperDate for the last day of the given month", () => {
-      expectEqualDates(new ProperDate("2023-12-25").endOfMonth, new ProperDate("2023-12-31"));
-      expectEqualDates(new ProperDate("2023-12-31").endOfMonth, new ProperDate("2023-12-31"));
-      expectEqualDates(new ProperDate("2025-11-11").endOfMonth, new ProperDate("2025-11-30"));
+      expectEqualProperDates(new ProperDate("2023-12-25").endOfMonth, new ProperDate("2023-12-31"));
+      expectEqualProperDates(new ProperDate("2023-12-31").endOfMonth, new ProperDate("2023-12-31"));
+      expectEqualProperDates(new ProperDate("2025-11-11").endOfMonth, new ProperDate("2025-11-30"));
 
       // February
-      expectEqualDates(new ProperDate("2024-02-01").endOfMonth, new ProperDate("2024-02-29"));
-      expectEqualDates(new ProperDate("2023-02-01").endOfMonth, new ProperDate("2023-02-28"));
+      expectEqualProperDates(new ProperDate("2024-02-01").endOfMonth, new ProperDate("2024-02-29"));
+      expectEqualProperDates(new ProperDate("2023-02-01").endOfMonth, new ProperDate("2023-02-28"));
     });
   });
 
   describe("#endOfYear", () => {
     test("returns a ProperDate for 12/31 of the given year", () => {
-      expectEqualDates(new ProperDate("2023-12-25").endOfYear, new ProperDate("2023-12-31"));
-      expectEqualDates(new ProperDate("2023-12-31").endOfYear, new ProperDate("2023-12-31"));
-      expectEqualDates(new ProperDate("2025-11-11").endOfYear, new ProperDate("2025-12-31"));
-      expectEqualDates(new ProperDate("1981-01-01").endOfYear, new ProperDate("1981-12-31"));
-      expectEqualDates(new ProperDate("1981-01-01").endOfYear, new ProperDate("1981-12-31"));
+      expectEqualProperDates(new ProperDate("2023-12-25").endOfYear, new ProperDate("2023-12-31"));
+      expectEqualProperDates(new ProperDate("2023-12-31").endOfYear, new ProperDate("2023-12-31"));
+      expectEqualProperDates(new ProperDate("2025-11-11").endOfYear, new ProperDate("2025-12-31"));
+      expectEqualProperDates(new ProperDate("1981-01-01").endOfYear, new ProperDate("1981-12-31"));
+      expectEqualProperDates(new ProperDate("1981-01-01").endOfYear, new ProperDate("1981-12-31"));
     });
   });
 });

--- a/tests/support/matchers.ts
+++ b/tests/support/matchers.ts
@@ -1,9 +1,19 @@
 import type ProperDate from "../../lib";
 
-export const expectEqualDates = (actual: ProperDate, expected: ProperDate) => {
+export const expectEqualProperDates = (actual: ProperDate, expected: ProperDate) => {
   try {
     expect(actual.equals(expected)).toBe(true);
   } catch (_error) {
     throw new Error(`Expected ${actual.toString()} to equal ${expected.toString()}`);
+  }
+};
+
+export const expectEqualDates = (actual: Date, expected: Date) => {
+  try {
+    const actualDateString = actual.toISOString().split("T")[0];
+    const expectedDateString = expected.toISOString().split("T")[0];
+    expect(actualDateString).toBe(expectedDateString);
+  } catch (_error) {
+    throw new Error(`Expected ${actual.toISOString()} to equal ${expected.toISOString()}`);
   }
 };

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -63,7 +63,7 @@ describe("utils", () => {
       expect(result.day).toStrictEqual(25);
     });
 
-    describe.skip("with a JavaScript date, without a specific timezone", () => {
+    describe("with a JavaScript date, without a specific timezone", () => {
       test("when constructed from a string", () => {
         const date = new Date("2023-12-25");
         const result = parseInput(date);
@@ -81,7 +81,7 @@ describe("utils", () => {
       });
     });
 
-    describe.skip("with a JavaScript date and a specific timezone", () => {
+    describe("with a JavaScript date and a specific timezone", () => {
       test("UTC/GMT", () => {
         const date = new Date("2023-12-25T00:00:00.000Z");
         const result = parseInput(date);

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,31 +1,32 @@
 import ProperDate from "../lib";
-import { buildUtcDate, parseInput } from "../lib/utils";
+import { buildDate, parseInput } from "../lib/utils";
+import { expectEqualDates } from "./support/matchers";
 
 describe("utils", () => {
-  describe("buildUtcDate", () => {
-    test("returns a UTC date", () => {
-      expect(buildUtcDate(2023, 12, 25)).toStrictEqual(new Date("2023-12-25T00:00:00.000Z"));
-      expect(buildUtcDate(2023, 12, 26)).toStrictEqual(new Date("2023-12-26T00:00:00.000Z"));
-      expect(buildUtcDate(2023, 12, 31)).toStrictEqual(new Date("2023-12-31T00:00:00.000Z"));
+  describe("buildDate", () => {
+    test("returns a date in the local timezone", () => {
+      expectEqualDates(buildDate(2023, 12, 25), new Date("2023-12-25T00:00:00.000Z"));
+      expectEqualDates(buildDate(2023, 12, 26), new Date("2023-12-26T00:00:00.000Z"));
+      expectEqualDates(buildDate(2023, 12, 31), new Date("2023-12-31T00:00:00.000Z"));
 
-      expect(buildUtcDate(2024, 2, 28)).toStrictEqual(new Date("2024-02-28T00:00:00.000Z"));
-      expect(buildUtcDate(2024, 2, 29)).toStrictEqual(new Date("2024-02-29T00:00:00.000Z"));
-      expect(buildUtcDate(2024, 3, 1)).toStrictEqual(new Date("2024-03-01T00:00:00.000Z"));
+      expectEqualDates(buildDate(2024, 2, 28), new Date("2024-02-28T00:00:00.000Z"));
+      expectEqualDates(buildDate(2024, 2, 29), new Date("2024-02-29T00:00:00.000Z"));
+      expectEqualDates(buildDate(2024, 3, 1), new Date("2024-03-01T00:00:00.000Z"));
     });
 
     test("handles day wrapping", () => {
-      expect(buildUtcDate(2023, 2, 35)).toStrictEqual(new Date("2023-03-07T00:00:00.000Z"));
-      expect(buildUtcDate(2024, 1, 15 + 366)).toStrictEqual(new Date("2025-01-15T00:00:00.000Z"));
+      expectEqualDates(buildDate(2023, 2, 35), new Date("2023-03-07T00:00:00.000Z"));
+      expectEqualDates(buildDate(2024, 1, 15 + 366), new Date("2025-01-15T00:00:00.000Z"));
     });
 
     test("handles month wrapping", () => {
-      expect(buildUtcDate(2023, 13, 2)).toStrictEqual(new Date("2024-01-02:00:00.000Z"));
-      expect(buildUtcDate(2024, 0, 2)).toStrictEqual(new Date("2023-12-02:00:00.000Z"));
+      expectEqualDates(buildDate(2023, 13, 2), new Date("2024-01-02:00:00.000Z"));
+      expectEqualDates(buildDate(2024, 0, 2), new Date("2023-12-02:00:00.000Z"));
     });
 
     test("handles end of month utilities", () => {
-      expect(buildUtcDate(2023, 12, 0)).toStrictEqual(new Date("2023-11-30:00:00.000Z"));
-      expect(buildUtcDate(2024, 3, 0)).toStrictEqual(new Date("2024-02-29:00:00.000Z"));
+      expectEqualDates(buildDate(2023, 12, 0), new Date("2023-11-30:00:00.000Z"));
+      expectEqualDates(buildDate(2024, 3, 0), new Date("2024-02-29:00:00.000Z"));
     });
   });
 
@@ -62,7 +63,7 @@ describe("utils", () => {
       expect(result.day).toStrictEqual(25);
     });
 
-    describe("with a JavaScript date, without a specific timezone", () => {
+    describe.skip("with a JavaScript date, without a specific timezone", () => {
       test("when constructed from a string", () => {
         const date = new Date("2023-12-25");
         const result = parseInput(date);
@@ -72,7 +73,7 @@ describe("utils", () => {
       });
 
       test("when constructed numerically", () => {
-        const date = new Date(Date.UTC(2023, 11, 25));
+        const date = new Date(2023, 11, 25);
         const result = parseInput(date);
         expect(result.year).toStrictEqual(2023);
         expect(result.month).toStrictEqual(11);
@@ -80,7 +81,7 @@ describe("utils", () => {
       });
     });
 
-    describe("with a JavaScript date and a specific timezone", () => {
+    describe.skip("with a JavaScript date and a specific timezone", () => {
       test("UTC/GMT", () => {
         const date = new Date("2023-12-25T00:00:00.000Z");
         const result = parseInput(date);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new function to normalize Date objects for consistent date extraction.

* **Refactor**
  * Switched all date construction and parsing logic from UTC-based to local-time-based handling across the app.

* **Tests**
  * Updated test assertions to use specialized matchers for comparing ProperDate and native Date objects.
  * Adjusted tests to reflect the transition to local-time date handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->